### PR TITLE
Fix typo in Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Qrize.getHash({
 })
 
 Qrize.getUrl({
-  url: '8jLDWGQ',
+  hash: '8jLDWGQ',
   onSuccess({ url }) {
     console.log(url);
   }


### PR DESCRIPTION
Wrong parameter name in example of usage of Qrize.getUrl method